### PR TITLE
Enhance order settlement didn't update order status when 3rd party Eventpress plugin is used

### DIFF
--- a/class/class.midtrans-gateway-notif-handler.php
+++ b/class/class.midtrans-gateway-notif-handler.php
@@ -259,6 +259,8 @@ class WC_Gateway_Midtrans_Notif_Handler
           $this->checkAndHandleWCSubscriptionTxnNotif( $midtrans_notification, $order );
         }
         $order->payment_complete();
+        $order->update_status('completed',__('Completed payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
+
         $order->add_order_note(__('Midtrans payment completed: capture. Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
 
       }
@@ -279,6 +281,8 @@ class WC_Gateway_Midtrans_Notif_Handler
     else if ($midtrans_notification->transaction_status == 'settlement') {
       if($midtrans_notification->payment_type != 'credit_card'){
         $order->payment_complete();
+        $order->update_status('completed',__('Completed payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
+
         $order->add_order_note(__('Midtrans payment completed: settlement. Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
       }
     }


### PR DESCRIPTION
https://demo.vaincode.com/mage-event/documentation/customer-order-event-emails/
order, didn't update to complete if midtrans notification handle was settlement.

i just add some minor solution for those notification handler, idk if my solution is right but  it solved my prob