### PR TITLE
V2.30.1 hotfix & feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ If required to change API endpoint/url, these are where you need to change:
 	- Replace any Snap API domain: https://app.sandbox.midtrans.com with UAT API domain
 </details>
 
+#### Customize Order Status on Payment Paid
+
+You can configure the status that WooCommerce Order should become when an order is successfully paid. This can be useful if you want, for example, order status to become "completed" once paid.
+
+Configure it from **WooCommerce > Settings > Payment > Midtrans > Manage** under configuration field **WC Order Status on Payment Paid**. Select your preferred value from the drop down.
+
 #### Available Custom Hooks
 
 <details><summary>Click to expand info</summary>
@@ -128,7 +134,7 @@ If required to change API endpoint/url, these are where you need to change:
 
 If you are a developer or know how to customize Wordpress, this section may be useful for you in case you want to customize some code/behaviour of this plugin.
 
-This plugin have few available [WP hooks](ttps://developer.wordpress.org/plugins/hooks/):
+This plugin have few available [WP hooks](https://developer.wordpress.org/plugins/hooks/):
 - filter: `midtrans_snap_params_main_before_charge` (1 params)
 	- For if you want to modify Snap API JSON param on the main gateway, before transaction is created on Midtrans side.
 - action: `midtrans_after_notification_payment_complete` (2 params)

--- a/class/class.midtrans-gateway-notif-handler.php
+++ b/class/class.midtrans-gateway-notif-handler.php
@@ -226,7 +226,16 @@ class WC_Gateway_Midtrans_Notif_Handler
       do_action( 'midtrans_after_notification_payment_complete', 
         $order, $midtrans_notification );
 
-      // @TODO: check if plugin settings: custom_payment_complete_status !== 'default', then $order->update_status() according to choosen custom status
+      // apply custom order status mapping coming from custom_payment_complete_status config value
+      $plugin_options = $this->getPluginOptions($plugin_id);
+      if( array_key_exists('custom_payment_complete_status',$plugin_options)
+          && $plugin_options['custom_payment_complete_status'] !== 'default'
+        ){
+        $order->update_status(
+          $plugin_options['custom_payment_complete_status'],
+          __('Status auto-updated via custom status mapping config: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce')
+        );
+      }
     }
     else if ($midtrans_notification->transaction_status == 'capture' && $midtrans_notification->fraud_status == 'challenge') {
       $order->update_status('on-hold',__('Challanged payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));

--- a/class/class.midtrans-gateway-notif-handler.php
+++ b/class/class.midtrans-gateway-notif-handler.php
@@ -212,21 +212,24 @@ class WC_Gateway_Midtrans_Notif_Handler
     // allow merchant-defined custom action function to perform action on $order upon notif handling
     do_action( 'midtrans_on_notification_received', $order, $midtrans_notification );
 
-    if ($midtrans_notification->transaction_status == 'capture') {
-      if ($midtrans_notification->fraud_status == 'accept') {
-        // Procces subscription transaction if contains subsctription
-        if( class_exists( 'WC_Subscriptions' ) ){
-          $this->checkAndHandleWCSubscriptionTxnNotif( $midtrans_notification, $order );
-        }
-        $order->payment_complete($midtrans_notification->transaction_id);
-        $order->add_order_note(__('Midtrans payment completed: capture. Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
-        // allow merchant-defined custom action function to perform action on $order
-        do_action( 'midtrans_after_notification_payment_complete', 
-          $order, $midtrans_notification );
+    if ( $midtrans_notification->transaction_status == 'settlement'
+      || ($midtrans_notification->transaction_status == 'capture' && $midtrans_notification->fraud_status == 'accept') ) {
+      // success scenario of payment paid
+
+      // Procces subscription transaction if contains subsctription for card transaction
+      if( $midtrans_notification->transaction_status == 'capture' && class_exists( 'WC_Subscriptions' ) ){
+        $this->checkAndHandleWCSubscriptionTxnNotif( $midtrans_notification, $order );
       }
-      else if ($midtrans_notification->fraud_status == 'challenge') {
-        $order->update_status('on-hold',__('Challanged payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
-      }
+      $order->payment_complete($midtrans_notification->transaction_id);
+      $order->add_order_note(__('Midtrans payment completed: '.$midtrans_notification->transaction_status.'. Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
+      // allow merchant-defined custom action function to perform action on $order
+      do_action( 'midtrans_after_notification_payment_complete', 
+        $order, $midtrans_notification );
+
+      // @TODO: check if plugin settings: custom_payment_complete_status !== 'default', then $order->update_status() according to choosen custom status
+    }
+    else if ($midtrans_notification->transaction_status == 'capture' && $midtrans_notification->fraud_status == 'challenge') {
+      $order->update_status('on-hold',__('Challanged payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
     }
     else if ($midtrans_notification->transaction_status == 'cancel') {
       $order->update_status('cancelled',__('Cancelled payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
@@ -237,15 +240,6 @@ class WC_Gateway_Midtrans_Notif_Handler
     else if ($midtrans_notification->transaction_status == 'deny') {
       // do nothing on deny, allow payment retries
       // $order->update_status('failed',__('Denied payment: Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
-    }
-    else if ($midtrans_notification->transaction_status == 'settlement') {
-      if($midtrans_notification->payment_type != 'credit_card'){
-        $order->payment_complete($midtrans_notification->transaction_id);
-        $order->add_order_note(__('Midtrans payment completed: settlement. Midtrans-'.$midtrans_notification->payment_type,'midtrans-woocommerce'));
-        // allow merchant-defined custom action function to perform action on $order
-        do_action( 'midtrans_after_notification_payment_complete', 
-          $order, $midtrans_notification );
-      }
     }
     else if ($midtrans_notification->transaction_status == 'pending') {
       // Store snap token & snap redirect url to $order metadata

--- a/class/midtrans-admin-settings.php
+++ b/class/midtrans-admin-settings.php
@@ -111,6 +111,21 @@ return apply_filters(
             'class'         => 'toggle-advanced',
             'default'       => 'no'
         ),
+        'custom_payment_complete_status' => array(
+            'title'         => __( 'WC Order Status on Payment Paid', 'midtrans-woocommerce' ),
+            'type'          => 'select',
+            'label'         => __( 'Map WC Order status to value', 'midtrans-woocommerce' ),
+            'description'   => __( 'The status that WooCommerce Order should become when an order is successfully paid. This can be useful if you want, for example, order status to become "completed" once paid.', 'midtrans-woocommerce' ),
+            'class'         => 'toggle-advanced',
+            'options' => array(
+                'default' => __('default', 'midtrans-woocommerce'),
+                'processing' => __('processing', 'midtrans-woocommerce'),
+                'completed' => __('completed', 'midtrans-woocommerce'),
+                'on-hold' => __('on-hold', 'midtrans-woocommerce'),
+                'pending' => __('pending', 'midtrans-woocommerce'),
+            ),
+            'default'       => 'default'
+        ),
         'enable_redirect'               => array(
             'title'         => __( 'Redirect payment mode', 'midtrans-woocommerce' ),
             'type'          => 'checkbox',

--- a/readme.txt
+++ b/readme.txt
@@ -73,8 +73,9 @@ The best way please email to support@midtrans.com, but bugs can be reported in o
 == Changelog ==
 
 = 2.30.1 - 2021-08-09 =
-* prevent issue "cannot inherit abstract function" on outdated PHP v5.0.0 - v5.3.8
+* prevent issue "cannot inherit abstract function" on outdated PHP v5.0.0 - v5.3.8 & v7.0.0 - v7.1.x
 * minor description improvement
+* add config to allow [Customize WooCommerce Order Status upon Payment Paid ](https://docs.midtrans.com/en/snap/with-plugins?id=advanced-customize-woocommerce-order-status-upon-payment-paid)
 
 = 2.30.0 - 2021-08-06 =
 * major feature: sub [specific gateway buttons for each](https://docs.midtrans.com/en/snap/with-plugins?id=advanced-specific-payment-buttons) supported payment methods
@@ -255,8 +256,9 @@ The best way please email to support@midtrans.com, but bugs can be reported in o
 == Upgrade Notice ==
 
 = 2.30.1 - 2021-08-09 =
-* prevent issue "cannot inherit abstract function" on outdated PHP v5.0.0 - v5.3.8
+* prevent issue "cannot inherit abstract function" on outdated PHP v5.0.0 - v5.3.8 & v7.0.0 - v7.1.x
 * minor description improvement
+* add config to allow [Customize WooCommerce Order Status upon Payment Paid ](https://docs.midtrans.com/en/snap/with-plugins?id=advanced-customize-woocommerce-order-status-upon-payment-paid)
 
 = 2.30.0 - 2021-08-06 =
 * major feature: sub [specific gateway buttons for each](https://docs.midtrans.com/en/snap/with-plugins?id=advanced-specific-payment-buttons) supported payment methods


### PR DESCRIPTION
* prevent issue "cannot inherit abstract function" on outdated PHP v5.0.0 - v5.3.8 & v7.0.0 - v7.1.x
* minor description improvement
* add config to allow [Customize WooCommerce Order Status upon Payment Paid ](https://docs.midtrans.com/en/snap/with-plugins?id=advanced-customize-woocommerce-order-status-upon-payment-paid)