### PR TITLE
fix: make sure midtrans-payment-page.js load with JQuery

### DIFF
--- a/class/payment-page.php
+++ b/class/payment-page.php
@@ -150,7 +150,7 @@ EOT;
   // output main.js script tag to html
   echo wp_get_script_tag(
     array(
-      'data-cfasync' => 'false',
+      'data-cfasync' => 'true',
       'src' => $main_script_url,
     )
   );


### PR DESCRIPTION
This plugin unable to load JQuery, maybe conflict with some other plugin, make "data-cfasync" to true resolved the issue
![Screenshot_227](https://user-images.githubusercontent.com/15825376/131527111-0388e883-d18f-43a7-8786-01b750939952.png)

