### PR TITLE
Remove jquery from payment page

### DIFF
--- a/midtrans-gateway.php
+++ b/midtrans-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Midtrans - WooCommerce Payment Gateway
 Plugin URI: https://github.com/veritrans/SNAP-Woocommerce
 Description: Accept all payment directly on your WooCommerce site in a seamless and secure checkout environment with <a  target="_blank" href="https://midtrans.com/">Midtrans</a>
-Version: 2.31.0
+Version: 2.31.1
 Author: Midtrans
 Author URI: http://midtrans.co.id
 License: GPLv2 or later

--- a/public/js/midtrans-payment-page-main.js
+++ b/public/js/midtrans-payment-page-main.js
@@ -1,6 +1,6 @@
 // wc_midtrans var is passed from payment-page backend via inline script.
 
-;(function( $, window, document ) {
+;(function( window, document ) {
   var payButton = document.getElementById("pay-button");
 
   /**
@@ -242,5 +242,4 @@
 
   handlePayAction();
   payButton.innerHTML = "Proceed To Payment";
-})( jQuery, window, document );
-// well jQuery is not actually used, just for formality
+})( window, document );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yocki, rizdaprasetya
 Tags: midtrans, snap, payment, payment-gateway, credit-card, commerce, e-commerce, woocommerce, veritrans
 Requires at least: 3.9.1
 Tested up to: 5.8
-Stable tag: 2.31.0
+Stable tag: 2.31.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -71,6 +71,9 @@ The best way please email to support@midtrans.com, but bugs can be reported in o
 4. Configuration page
 
 == Changelog ==
+
+= 2.31.1 - 2021-09-01 =
+* improve compatibility with external optimizer plugins on payment page JS (remove jQuery dependency)
 
 = 2.31.0 - 2021-08-26 =
 * handle duplicated Snap order_id (incase WP is reinstalled, or DB restored) by auto-adding suffix
@@ -261,6 +264,9 @@ The best way please email to support@midtrans.com, but bugs can be reported in o
 * Fullpayment feature
 
 == Upgrade Notice ==
+
+= 2.31.1 - 2021-09-01 =
+* improve compatibility with external optimizer plugins on payment page JS (remove jQuery dependency)
 
 = 2.31.0 - 2021-08-26 =
 * handle duplicated Snap order_id (incase WP is reinstalled, or DB restored) by auto-adding suffix


### PR DESCRIPTION
Address this https://github.com/veritrans/SNAP-Woocommerce/issues/63

To avoid edge-case issue: when merchant use unknown 3rd party asset optimizer plugin, on payment page, jQuery may be loaded late/randomly (race condition). it can cause jQuery is undefined that prevent the payment js to run.