### PR TITLE
Fix refund notif handler and bump version compatibility

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -88,17 +88,17 @@ Plugin WP Hosted url: https://wordpress.org/plugins/midtrans-woocommerce/
     - `Requires at least:` {min version of WP, rarely changes: x.x.x}
     - `Tested up to:` {latest WP version: x.x.x}
     - `Stable tag:` {latest/stable version of this plugin (must have its own /trunk folder): x.x.x}
-- Copy contents of Github root folder `Snap-Woocommerce` into your SVN folder, under `/trunk` folder
-- Create new folder under `/tags` folder, name it with the plugin version. e.g: `2.6.3`
-  - or alternatively, better use [SVN command to do it](https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/#create-tags-from-trunk) by running script `svn copy /trunk /tags/2.6.3`. SVN will copy the trunk folder into new version tag folder.
-- Ensure `Stable tag` value within `readme.txt` in folder `trunk` have the same value as above e.g: `2.6.3`
+- Copy contents of Github root folder `Snap-Woocommerce` into your SVN folder, under `trunk/` folder
+- Create new folder under `tags/` folder, name it with the plugin version. e.g: `2.6.3`
+  - or alternatively, better use [SVN command to do it](https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/#create-tags-from-trunk) by running script `svn copy trunk tags/2.6.3`. SVN will copy the trunk folder into new version tag folder.
+- Ensure `Stable tag` value within `readme.txt` in folder `trunk/` have the same value as above e.g: `2.6.3`
   - values that need to be consistent:
-    - stable tag in readme.txt `/trunk`
-    - stable tag in readme.txt `/tags/[new version folder]`
+    - stable tag in readme.txt `trunk/`
+    - stable tag in readme.txt `tags/[new version folder]/`
     - version in `midtrans-gateway.php`
 
 Note, alternatively can also:
-- First, svn push the `/tags/[new version folder]`, ensure have been pushed on WP svn.
+- First, svn push the `tags/[new version folder]/`, ensure have been pushed on WP svn.
 - Then, edit the readme / trunks version value to match the new version, then push svn again.
 
 Note, if you are deleting commited files:

--- a/abstract/abstract.midtrans-gateway.php
+++ b/abstract/abstract.midtrans-gateway.php
@@ -355,7 +355,7 @@ abstract class WC_Gateway_Midtrans_Abstract extends WC_Payment_Gateway {
    * @return WC_Order_Refund|WP_Error
    */
   public function midtrans_refund( $order_id, $refund_amount, $refund_reason, $isFullRefund = false ) {
-    $order_id = WC_Midtrans_Utils::check_and_restore_original_order_id();
+    $order_id = WC_Midtrans_Utils::check_and_restore_original_order_id($order_id);
     $order  = wc_get_order( $order_id );
     if( ! is_a( $order, 'WC_Order') ) {
       return;

--- a/midtrans-gateway.php
+++ b/midtrans-gateway.php
@@ -8,7 +8,7 @@ Author: Midtrans
 Author URI: http://midtrans.co.id
 License: GPLv2 or later
 WC requires at least: 2.0.0
-WC tested up to: 6.1
+WC tested up to: 7.2.2
 */
 
 /*

--- a/midtrans-gateway.php
+++ b/midtrans-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Midtrans - WooCommerce Payment Gateway
 Plugin URI: https://github.com/veritrans/SNAP-Woocommerce
 Description: Accept all payment directly on your WooCommerce site in a seamless and secure checkout environment with <a  target="_blank" href="https://midtrans.com/">Midtrans</a>
-Version: 2.32.1
+Version: 2.32.2
 Author: Midtrans
 Author URI: http://midtrans.co.id
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: yocki, rizdaprasetya
 Tags: midtrans, snap, payment, payment-gateway, credit-card, commerce, e-commerce, woocommerce, veritrans
 Requires at least: 3.9.1
-Stable tag: 2.32.1
 Tested up to: 6.1
+Stable tag: 2.32.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -71,6 +71,10 @@ The best way please email to support@midtrans.com, but bugs can be reported in o
 4. Configuration page
 
 == Changelog ==
+
+= 2.32.2 - 2023-01-02 =
+* prevent issue of Midtrans payment webhook notification of refund status causing unexpected error on WooCommerce
+* bump tested compatibility with current latest version of WordPress & WooCommerce
 
 = 2.32.1 - 2021-02-08 =
 * minor plugin size reduction by removing unused assets
@@ -273,6 +277,10 @@ The best way please email to support@midtrans.com, but bugs can be reported in o
 * Fullpayment feature
 
 == Upgrade Notice ==
+
+= 2.32.2 - 2023-01-02 =
+* prevent issue of Midtrans payment webhook notification of refund status causing unexpected error on WooCommerce
+* bump tested compatibility with current latest version of WordPress & WooCommerce
 
 = 2.32.1 - 2021-02-08 =
 * minor plugin size reduction by removing unused assets

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: yocki, rizdaprasetya
 Tags: midtrans, snap, payment, payment-gateway, credit-card, commerce, e-commerce, woocommerce, veritrans
 Requires at least: 3.9.1
-Tested up to: 5.9
 Stable tag: 2.32.1
+Tested up to: 6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
- Fixes https://github.com/veritrans/SNAP-Woocommerce/issues/76
- check readme.txt for details